### PR TITLE
Extend ContextMapStrategy to mapAsyncUnordered

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/WithContextUsageSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/WithContextUsageSpec.scala
@@ -5,6 +5,7 @@
 package akka.stream.scaladsl
 
 import akka.NotUsed
+import akka.stream.ContextMapStrategy
 import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.TestSubscriber.Probe
 import akka.stream.testkit.scaladsl.TestSink
@@ -12,6 +13,13 @@ import akka.stream.testkit.scaladsl.TestSink
 import scala.collection.immutable
 
 class WithContextUsageSpec extends StreamSpec {
+
+  // The approach demonstrated in this spec works for streams that allow iteration/filtering but
+  // not reordering.
+  // I wonder if we can use the strategy approach to replace this approach with this nicer entirely, though.
+  def strategy[Ctx] = new ContextMapStrategy[Ctx] with ContextMapStrategy.Iteration[Ctx] {
+    override def next(in: Ctx, index: Long, hasNext: Boolean): Ctx = in
+  }
 
   "Context propagation used for committing offsets" must {
 
@@ -49,7 +57,7 @@ class WithContextUsageSpec extends StreamSpec {
       val expectedOffsets = input.filter(cm => f(cm.record)).map(cm => Offset(cm)).init
       val expectedRecords = toRecords(input).filter(f)
 
-      val src = createSourceWithContext(input).filter(f).asSource
+      val src = createSourceWithContext(input).filter(f, strategy).asSource
 
       src
         .map { case (e, _) => e }
@@ -75,7 +83,7 @@ class WithContextUsageSpec extends StreamSpec {
       val expectedOffsets = testRange.map(ix => Offset(ix)).init
       val expectedRecords = toRecords(input).flatMap(f)
 
-      val src = createSourceWithContext(input).mapConcat(f).asSource
+      val src = createSourceWithContext(input).mapConcat(f, strategy).asSource
 
       src
         .map { case (e, _) => e }
@@ -132,7 +140,7 @@ class WithContextUsageSpec extends StreamSpec {
       val expectedMultiRecords = toRecords(input).flatMap(f).grouped(groupSize).map(l => MultiRecord(l)).toVector
 
       val src = createSourceWithContext(input)
-        .mapConcat(f)
+        .mapConcat(f, strategy)
         .grouped(groupSize)
         .map(l => MultiRecord(l))
         .mapContext(_.last)

--- a/akka-stream/src/main/scala/akka/stream/ContextMapStrategy.scala
+++ b/akka-stream/src/main/scala/akka/stream/ContextMapStrategy.scala
@@ -4,53 +4,35 @@
 
 package akka.stream
 
+/**
+ * A ContextMapStrategy defines how the context parameter of a FlowWithContext is manipulated
+ * as various operations are performed in the flow
+ *
+ * @typeparam Ctx the context type
+ */
+class ContextMapStrategy[-Ctx]
+
 object ContextMapStrategy {
-
-  final case class Iterate[In, Ctx, Out](
-      iterateFn: (In, Ctx, Out, Int, Boolean) => Ctx,
-      emptyFn: Option[(In, Ctx) => (Out, Ctx)] = None)
+  /**
+   * Trait that is mixed into strategies that allow elements (including their offsets) to be filtered out of the stream.
+   */
+  trait Filtering[-Ctx] {
+    self: ContextMapStrategy[Ctx] =>
+  }
 
   /**
-   * Passthrough the same context [[Ctx] of the input element [[In]] to all output elements [[Out]].
+   * Trait that is mixed into strategies that allow elements (including their offsets) to be reordered.
    */
-  def same[In, Ctx, Out](): Iterate[In, Ctx, Out] = Iterate(
-    iterateFn = (_: In, inCtx: Ctx, _: Out, _: Int, _: Boolean) => inCtx
-  )
+  trait Reordering[-Ctx] {
+    self: ContextMapStrategy[Ctx] =>
+  }
 
   /**
-   * Transform the context of the first element given the input element [[In]] and context [[Ctx]].
+   * Trait that is mixed into strategies that allows operations like 'mapConcat', which
+   * turn a single element into zero or more elements, where it is known before the last
+   * element is emitted that this is the last element.
    */
-  def first[In, Ctx, Out](firstFn: (In, Ctx, Out) => Ctx): Iterate[In, Ctx, Out] = Iterate(
-    iterateFn = (in: In, inCtx: Ctx, out: Out, index: Int, _: Boolean) =>
-      if (index == 0) firstFn(in, inCtx, out)
-      else inCtx
-  )
-
-  /**
-   * Transform the context of the last element given the input element [[In]], context [[Ctx]], and the index
-   * of the element.
-   */
-  def last[In, Ctx, Out](fn: (In, Ctx, Out, Int) => Ctx): Iterate[In, Ctx, Out] = Iterate(
-    iterateFn = (in: In, inCtx: Ctx, out: Out, index: Int, hasNext: Boolean) =>
-      if (!hasNext) fn(in, inCtx, out, index)
-      else inCtx
-  )
-
-  /**
-   * Iterate over each element and transform the context given the element [[In]], context [[InCtx]],
-   * output element [[Out]], index, and if the there is a next output element [[Out]]. This strategy can be used to
-   * satisfy all 1:many use cases.
-   */
-  def iterate[In, Ctx, Out](fn: (In, Ctx, Out, Int, Boolean) => Ctx): Iterate[In, Ctx, Out] = Iterate(fn)
-
-  /**
-   * Iterate over each element and transform the context given the element [[In]], context [[InCtx]],
-   * output element [[Out]], index, and if the there is a next output element [[Out]]. If there are no output elements
-   * then we can emit a single output element [[Out]] and output context [[Ctx]] that represents this state.
-   * This strategy can be used to satisfy all 1:many and 1:0 use cases.
-   */
-  def iterateOrEmpty[In, Ctx, Out](
-                                    fn: (In, Ctx, Out, Int, Boolean) => Ctx,
-                                    emptyFn: (In, Ctx) => (Out, Ctx)
-                                  ): Iterate[In, Ctx, Out] = Iterate(iterateFn = fn, emptyFn = Some(emptyFn))
+  trait Iteration[Ctx] extends Filtering[Ctx] { self: ContextMapStrategy[Ctx] =>
+    def next(in: Ctx, index: Long, hasNext: Boolean): Ctx
+  }
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -2234,7 +2234,7 @@ private[stream] object Collect {
  */
 @InternalApi private[akka] final class StatefulMapConcatWithContext[In, Ctx, Out](
   val f: () => In => immutable.Iterable[Out],
-  val strategy: ContextMapStrategy.Iterate[In, Ctx, Out]
+  val strategy: ContextMapStrategy.Iteration[Ctx]
 )
   extends GraphStage[FlowShape[(In, Ctx), (Out, Ctx)]] {
   val in = Inlet[(In, Ctx)]("StatefulMapConcat.in")
@@ -2245,7 +2245,7 @@ private[stream] object Collect {
 
   def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with InHandler with OutHandler {
     lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
-    var index: Int = 0
+    var index: Long = 0
     var currentIn: (In, Ctx) = _
     var currentInElement: In = _
     var currentInContext: Ctx = _
@@ -2259,17 +2259,10 @@ private[stream] object Collect {
     def pushPull(): Unit = {
       if (hasNext) {
         val outElm: Out = currentOutIterator.next()
-        val outCtx: Ctx = strategy.iterateFn(currentInElement, currentInContext, outElm, index, hasNext)
-        index += 1
+        val outCtx: Ctx = strategy.next(currentInContext, index, hasNext)
+        index += 1L
         push(out, (outElm, outCtx))
         if (!hasNext && isClosed(in)) completeStage()
-      } else if (!hasNext && index == 0 && !isClosed(in) && currentInElement != null) {
-        strategy match {
-          case ContextMapStrategy.Iterate(_, Some(f)) if index == 0 =>
-            val (noneOut, noneOutContext): (Out, Ctx) = f(currentInElement, currentInContext)
-            push(out, (noneOut, noneOutContext))
-          case _ => ()
-        }
       }
       else if (!isClosed(in))
         pull(in)


### PR DESCRIPTION
This extends the `ContextMapStrategy` idea to `mapAsyncUnordered`. This
might help motivate the feature:

Previously, a big limitation of FlowWithContext is that it was somewhat
unclear what kinds of operations were allowed on streams in order not to
violate the expectations of the sinks that use that context.

For example, the current approach for dealing with Kafka commits in
contexts would allow filtering, but not reordering of the elements, and
mapConcat needed some careful massaging.

By putting the information of what is supported in the type of the ContextMapStrategy,
components that care about the offsets (like Alpakka Kafka) can provide
a strategy (or multiple) that allows only those operations that are safe
for them.

Components that provide context-aware flows but don't care about the
offsets themselves (such as generic alpakka components) can indicate
their restrictions in the type of the strategy they accept.

The test shows 2 possible Kafka strategies, one allowing iteration (but
not reordering) and one allowing reordering (but not filtering), and 2
example streams showing how this can be composed in a type-safe way.

This still doesn't cover flatMapConcat. For flatMapConcat, there are some
trade-offs: i.e. in the Kafka case, if you absolutely want all input elements
to be committed, AFAICS we would have to delay each element (until we know
whether the next event is the next element or the stream completion), which is
quite a cost. If you're OK with skipping some commits for filtered-out
input elements (which I'd say is typically reasonable), you don't have to
incur this cost by using the 'commit when changed' strategy. Signalling whether
this is necessary could also be done from the mapping strategy, and we could
provide 'strict' and 'loose' strategies corresponding the the different behaviours.
That sounds like it might fit rather nicely.

(I think there is another option that would only delay the commits, also fit
flatMapMerge and reordering (even at the same time), while only possibly missing
commits at the 'end' of the stream - but let's not get into the woods too far
yet ;))